### PR TITLE
fix: allow blank `updatedBy`

### DIFF
--- a/server/src/resolvers/contact.ts
+++ b/server/src/resolvers/contact.ts
@@ -19,7 +19,7 @@ class ContactInput {
     createdBy: string;
 
     @Field()
-    @Length(1, 50)
+    @Length(0, 50)
     updatedBy: string;
 
 }


### PR DESCRIPTION
- requiring a value for `updatedBy` causes error when creating contact